### PR TITLE
remove hard version requirement of suds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
     ],
 
     install_requires=[
-        'suds==0.3.9',
+        'suds',
     ],
 )


### PR DESCRIPTION
hard requirements shouldn't be included in setup.py, they belong in a requirements.txt file
